### PR TITLE
Added geocode search & auto geocode follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ By default, the bot looks up the 100 most recent tweets. You can change this num
     
     from twitter_follow_bot import auto_follow_followers_for_user
     
+####Automatically follow any users that tweet from a specific geolocation
+    
+    from twitter_follow_bot import auto_follow_geo
+    
+    auto_follow_geo("geocode") eg. "-27.4678802490,153.0470428467,20km" latitude,longitude,radis
+    
 ####Automatically follow any users that have followed you
 
     from twitter_follow_bot import auto_follow_followers


### PR DESCRIPTION
Hi there, I thought I might share the code I added to enable searching tweets via geocode functionality. The geocode argument may be able to be added in the inital twitter_search function, but I didn't want to mess around with existing code that might break something.

I've tested this and it seems to work well to follow people tweeting around me. Hopefully some others find this useful.