### PR TITLE
Unfollow only "botted" people

### DIFF
--- a/twitter_follow_bot.py
+++ b/twitter_follow_bot.py
@@ -18,16 +18,19 @@ You should have received a copy of the GNU General Public License along with the
 Follow Bot library. If not, see http://www.gnu.org/licenses/.
 """
 
-from twitter import Twitter, OAuth, TwitterHTTPError
 import os
 import pickle
 
+from twitter import Twitter, OAuth, TwitterHTTPError
+
+
+
 # put your tokens, keys, secrets, and Twitter handle in the following variables
-OAUTH_TOKEN = "2754806952-yBAbRDdkxvYKpImjRnsm7MEwCsNszjpbel4ZDTY"
-OAUTH_SECRET = "FFfebP9R2T43N4GUZhQntlzECCUulJoCDLZSaxPRbMp35"
-CONSUMER_KEY = "nm18SuFGYtyZUJEpfoYjWApKe"
-CONSUMER_SECRET = "brLlmlqjMt3rVCYH96oSuc4W9THrR8ndadpxEe1430PsFiDGjb"
-TWITTER_HANDLE = "simonuvarov"
+OAUTH_TOKEN = ""
+OAUTH_SECRET = ""
+CONSUMER_KEY = ""
+CONSUMER_SECRET = ""
+TWITTER_HANDLE = ""
 
 # put the full path and file name of the file you want to store your "already followed"
 # list in
@@ -97,36 +100,62 @@ def load_already_followed_list():
     if not os.path.isfile(ALREADY_FOLLOWED_FILE):
         with open(ALREADY_FOLLOWED_FILE, "w") as out_file:
             out_file.write("")
-            out_file.close()
 
     # read in the list of user IDs that the bot has already followed in the
     # past
     with open(ALREADY_FOLLOWED_FILE) as in_file:
-        already_followed = pickle.load(in_file)
-        in_file.close()
+        try:
+            already_followed = pickle.load(in_file)
+        except EOFError:
+            pass
 
     return already_followed
 
 
-def save_already_followed_list(af_list):
+def save_into_file(af, replace=False):
     """
-        Returns list of users the bot has already followed.
+        Saves set of users' id into file
     """
-    already_followed = set(af_list)
+    #TODO: some refactoring needed
 
-    # make sure the "already followed" file exists
-    if not os.path.isfile(ALREADY_FOLLOWED_FILE):
-        with open(ALREADY_FOLLOWED_FILE, "w") as out_file:
-            out_file.write("")
-            pickle.dump(already_followed, out_file)
-            out_file.close()
+    # load old value and update them with new values
+    # then save it
+    already_followed = set()
 
-def follow_user_by_id(user_id):
+    if not replace:
+        already_followed = load_already_followed_list()
+
+    already_followed.update(af)
+    with open(ALREADY_FOLLOWED_FILE, "w") as f:
+        pickle.dump(already_followed, f)
+
+
+def follow_by_id(user_id, save_changes = False):
     """
         Follows user by id
     """
     t.friendships.create(user_id=user_id, follow=False)
     print("followed %s" % user_id)
+    if save_changes:
+        _add_id_into_file(user_id)
+
+
+
+def _add_id_into_file(user_id):
+    """
+        Save user_id into file
+    """
+    already_followed = load_already_followed_list()
+    already_followed.update(set([user_id]))
+    save_into_file(already_followed)
+    print("added into file %d" % user_id)
+
+
+def _delete_id_from_file(user_id):
+    already_followed = load_already_followed_list()
+    already_followed -= set([user_id])
+    save_into_file(already_followed, replace=True)
+    print("deleted from file %d" % user_id)
 
 
 def auto_follow(q, count=100, result_type="recent"):
@@ -135,17 +164,15 @@ def auto_follow(q, count=100, result_type="recent"):
     """
 
     result = search_tweets(q, count, result_type)
-    following = set(t.friends.ids(screen_name=TWITTER_HANDLE)["ids"])
     do_not_follow = load_already_followed_list()
 
     for tweet in result["statuses"]:
         try:
             if (tweet["user"]["screen_name"] != TWITTER_HANDLE and
-                    tweet["user"]["id"] not in following and
+                    tweet["user"]["id"] not in load_already_followed_list() and
                     tweet["user"]["id"] not in do_not_follow):
 
-                follow_user_by_id(tweet["user"]["id"])
-                following.update(set([tweet["user"]["id"]]))
+                follow_by_id(tweet["user"]["id"], save_changes=True)
                 mute_user_by_id(tweet["user"]["id"])
 
         except TwitterHTTPError as e:
@@ -154,7 +181,6 @@ def auto_follow(q, count=100, result_type="recent"):
             # quit on error unless it's because someone blocked me
             if "blocked" not in str(e).lower():
                 quit()
-
 
 
 def auto_follow_followers_for_user(user_screen_name, count=100):
@@ -170,7 +196,7 @@ def auto_follow_followers_for_user(user_screen_name, count=100):
             if (user_id not in following and 
                 user_id not in do_not_follow):
 
-                follow_user_by_id(user_id)
+                follow_by_id(user_id, save_changes=True)
 
         except TwitterHTTPError as e:
             print("error: %s" % (str(e)))
@@ -187,9 +213,22 @@ def auto_follow_followers():
 
     for user_id in not_following_back:
         try:
-            follow_user_by_id(user_id)
+            follow_by_id(user_id, save_changes=True)
         except Exception as e:
             print("error: %s" % (str(e)))
+
+
+def unfollow_by_id(user_id, save_changes = False):
+    """
+        Unfollows user by id
+    """
+    t.friendships.destroy(user_id=user_id)
+    print("unfollowed %d" % (user_id))
+
+    if save_changes:
+        _delete_id_from_file(user_id)
+
+
 
 
 def auto_unfollow_nonfollowers():
@@ -197,38 +236,25 @@ def auto_unfollow_nonfollowers():
         Unfollows everyone who hasn't followed you back
     """
 
-    following = set(t.friends.ids(screen_name=TWITTER_HANDLE)["ids"])
+    # it checks if file exists so we don't have to do it again
+    already_followed = load_already_followed_list()
     followers = set(t.followers.ids(screen_name=TWITTER_HANDLE)["ids"])
 
     # put user IDs here that you want to keep following even if they don't
     # follow you back
     users_keep_following = set([])
 
-    not_following_back = following - followers
+    # searching for only in the already followed
+    # and don't touch those who we followed on purpose
+    not_following_back = already_followed - followers
 
-    # make sure the "already followed" file exists
-    if not os.path.isfile(ALREADY_FOLLOWED_FILE):
-        with open(ALREADY_FOLLOWED_FILE, "w") as out_file:
-            out_file.write("")
-
-    # update the "already followed" file with users who didn't follow back
-    already_followed = set(not_following_back)
-    af_list = []
-    with open(ALREADY_FOLLOWED_FILE) as in_file:
-        for line in in_file:
-            af_list.append(int(line))
-
-    already_followed.update(set(af_list))
-    del af_list
-
-    with open(ALREADY_FOLLOWED_FILE, "w") as out_file:
-        for val in already_followed:
-            out_file.write(str(val) + "\n")
+    unfollowed = []
 
     for user_id in not_following_back:
         if user_id not in users_keep_following:
-            t.friendships.destroy(user_id=user_id)
-            print("unfollowed %d" % (user_id))
+            unfollow_by_id(user_id, save_changes = True)
+
+
 
 
 def mute_user_by_id(user_id):
@@ -275,7 +301,9 @@ def auto_unmute():
 
 
 if __name__ == "__main__":
-    a = [1,2,3,4,5]
-    save_already_followed_list(a)
-    b = load_already_followed_list()
-    print b
+    auto_follow("english language", 10)
+    auto_unfollow_nonfollowers()
+
+
+
+

--- a/twitter_follow_bot.py
+++ b/twitter_follow_bot.py
@@ -22,11 +22,11 @@ from twitter import Twitter, OAuth, TwitterHTTPError
 import os
 
 # put your tokens, keys, secrets, and Twitter handle in the following variables
-OAUTH_TOKEN = ""
-OAUTH_SECRET = ""
-CONSUMER_KEY = ""
-CONSUMER_SECRET = ""
-TWITTER_HANDLE = ""
+OAUTH_TOKEN = "2754806952-yBAbRDdkxvYKpImjRnsm7MEwCsNszjpbel4ZDTY"
+OAUTH_SECRET = "FFfebP9R2T43N4GUZhQntlzECCUulJoCDLZSaxPRbMp35"
+CONSUMER_KEY = "nm18SuFGYtyZUJEpfoYjWApKe"
+CONSUMER_SECRET = "brLlmlqjMt3rVCYH96oSuc4W9THrR8ndadpxEe1430PsFiDGjb"
+TWITTER_HANDLE = "simonuvarov"
 
 # put the full path and file name of the file you want to store your "already followed"
 # list in
@@ -213,6 +213,10 @@ def auto_unfollow_nonfollowers():
             print("unfollowed %d" % (user_id))
 
 
+def mute_user_by_id(user_id):
+    t.mutes.users.create(user_id=user_id)
+
+
 def auto_mute_following():
     """
         Mutes everyone that you are following
@@ -228,8 +232,8 @@ def auto_mute_following():
     # mute all        
     for user_id in not_muted:
         if user_id not in users_keep_unmuted:
-            t.mutes.users.create(user_id=user_id)
-            print("muted %d" % (user_id))
+            mute_user_by_id(user_id)
+            print("muted %d" % user_id)
 
 
 def auto_unmute():
@@ -246,3 +250,8 @@ def auto_unmute():
         if user_id not in users_keep_muted:
             t.mutes.users.destroy(user_id=user_id)
             print("unmuted %d" % (user_id))
+
+
+if __name__ == "__main__":
+    #auto_follow("tv shows", 100)
+    auto_mute_following()


### PR DESCRIPTION
The main point is that now you can unfollow people you have followed earlier so that people you want to read stay in your followings. Also I extracted some standalone functions "as mute_by_id" and "follow_by_id". Fixed logical problems with gaining "not-to-follow" list.